### PR TITLE
Fix download links

### DIFF
--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -83,7 +83,7 @@
                         <p>Keep your passwords safe on the computer you trust. No clouds. No 3rd parties.</p>
                     </div>
 
-                    <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi" class="uk-button uk-button-primary uk-button-large download"><i class="fa-solid fa-download"></i> Download for Windows <span class="windows-version">11</span></a>
+                    <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi" class="uk-button uk-button-primary uk-button-large download"><i class="fa-solid fa-download"></i> Download for Windows <span class="windows-version">11</span></a>
                     <div class="uk-margin-small uk-text-small uk-margin-small uk-text-muted">
                         Version {{ .Params.version.version }} &ndash;
                         <a href="https://github.com/keepassxreboot/keepassxc/releases">Older Releases</a>
@@ -91,8 +91,8 @@
                     <div class="uk-margin-small uk-text-small uk-text-muted requires-msvc">Requires <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">MSVC Support Libraries</a></div>
 
                     <div class="uk-text-small uk-margin-medium uk-margin-medium-bottom uk-text-muted">
-                        <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi.sig" class="uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a> &ndash;
-                        <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi.DIGEST" class="uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a> &ndash;
+                        <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi.sig" class="uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a> &ndash;
+                        <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi.DIGEST" class="uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a> &ndash;
                         <a href="{{ .Site.BaseURL }}verifying-signatures" class="uk-padding-small"><i class="fa-solid fa-circle-question"></i> Verifying Signatures</a>
                     </div>
                 </div>
@@ -120,9 +120,9 @@
                                     <i class="fa-brands fa-windows"></i> Installer (64-bit, Windows 10 / 11)
                                 </div>
                                 <div class="uk-margin-small">
-                                    <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi" class="uk-button uk-button-secondary uk-button-small"><i class="fa-solid fa-download"></i> Download</a>
-                                    <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi.sig" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a>
-                                    <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi.DIGEST" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a>
+                                    <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi" class="uk-button uk-button-secondary uk-button-small"><i class="fa-solid fa-download"></i> Download</a>
+                                    <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi.sig" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a>
+                                    <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.msi }}-Win64.msi.DIGEST" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a>
                                 </div>
                             </div>
                             <div>
@@ -130,9 +130,9 @@
                                     <i class="fa-brands fa-windows"></i> Portable ZIP (64-bit, Windows 10 / 11)
                                 </div>
                                 <div class="uk-margin-small">
-                                    <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.portable }}-Win64.zip" class="uk-button uk-button-secondary uk-button-small"><i class="fa-solid fa-download"></i> Download</a>
-                                    <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.portable }}-Win64.zip.sig" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a>
-                                    <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.portable }}-Win64.zip.DIGEST" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a>
+                                    <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.portable }}-Win64.zip" class="uk-button uk-button-secondary uk-button-small"><i class="fa-solid fa-download"></i> Download</a>
+                                    <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.portable }}-Win64.zip.sig" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a>
+                                    <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.portable }}-Win64.zip.DIGEST" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a>
                                 </div>
                             </div>
                             <div>
@@ -140,9 +140,9 @@
                                     <i class="fa-brands fa-windows"></i> Legacy Installer (64-bit, Windows 7 / 8 / 8.1)
                                 </div>
                                 <div class="uk-margin-small">
-                                    <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.legacy }}-Win64-LegacyWindows.msi" class="uk-button uk-button-secondary uk-button-small"><i class="fa-solid fa-download"></i> Download</a>
-                                    <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.legacy }}-Win64-LegacyWindows.msi.sig" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a>
-                                    <a href="{{ $gh }}/{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.legacy }}-Win64-LegacyWindows.msi.DIGEST" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a>
+                                    <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.legacy }}-Win64-LegacyWindows.msi" class="uk-button uk-button-secondary uk-button-small"><i class="fa-solid fa-download"></i> Download</a>
+                                    <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.legacy }}-Win64-LegacyWindows.msi.sig" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a>
+                                    <a href="{{ $gh }}{{ .Params.version.version }}/KeePassXC-{{ .Params.version.version }}{{ .Params.version.suffix.windows.legacy }}-Win64-LegacyWindows.msi.DIGEST" class="uk-visible@s uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a>
                                 </div>
                             </div>
                             <div>
@@ -315,7 +315,7 @@
                         <p>Keep your passwords safe on the computer you trust. No clouds. No 3rd parties.</p>
                     </div>
 
-                    <a href="{{ $gh }}/{{ .Params.version.version }}/keepassxc-{{ .Params.version.version }}{{ .Params.version.suffix.source.tarball }}-src.tar.xz" class="uk-button uk-button-primary uk-button-large download"><i class="fa-solid fa-download"></i> Download Source Code</a>
+                    <a href="{{ $gh }}{{ .Params.version.version }}/keepassxc-{{ .Params.version.version }}{{ .Params.version.suffix.source.tarball }}-src.tar.xz" class="uk-button uk-button-primary uk-button-large download"><i class="fa-solid fa-download"></i> Download Source Code</a>
                     <div class="uk-margin-small uk-text-small uk-margin-small uk-text-muted">
                         Version {{ .Params.version.version }} &ndash;
                         <a href="https://github.com/keepassxreboot/keepassxc/releases">Older Releases</a>
@@ -323,8 +323,8 @@
                 </div>
 
                 <div class="uk-text-small uk-margin-medium uk-margin-medium-bottom uk-text-muted">
-                    <a href="{{ $gh }}/{{ .Params.version.version }}/keepassxc-{{ .Params.version.version }}{{ .Params.version.suffix.source.tarball }}-src.tar.xz.sig" class="uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a> &ndash;
-                    <a href="{{ $gh }}/{{ .Params.version.version }}/keepassxc-{{ .Params.version.version }}{{ .Params.version.suffix.source.tarball }}-src.tar.xz.DIGEST" class="uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a> &ndash;
+                    <a href="{{ $gh }}{{ .Params.version.version }}/keepassxc-{{ .Params.version.version }}{{ .Params.version.suffix.source.tarball }}-src.tar.xz.sig" class="uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a> &ndash;
+                    <a href="{{ $gh }}{{ .Params.version.version }}/keepassxc-{{ .Params.version.version }}{{ .Params.version.suffix.source.tarball }}-src.tar.xz.DIGEST" class="uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a> &ndash;
                     <a href="{{ .Site.BaseURL }}verifying-signatures" class="uk-padding-small"><i class="fa-solid fa-circle-question"></i> Verifying Signatures</a>
                 </div>
             </div>


### PR DESCRIPTION
The link to download the current Windows version is: `https://github.com/keepassxreboot/keepassxc/releases/download//2.7.4/KeePassXC-2.7.4-Win64.msi`.
It is not necessary to use double slashes.

The variable for the GitHub URL already contains a slash. Thus, there is no second slash needed in the `a href` tag.