### PR TITLE
FAQ: fix incorrect anchors to sections

### DIFF
--- a/content/docs/index.html
+++ b/content/docs/index.html
@@ -43,7 +43,7 @@ menu:
                     good pull requests were never merged and the original project is missing some features which users
                     can expect from a modern password manager. Hence, we decided to fork KeePassX to continue its
                     development
-                    and provide you with everything you love about KeePassX plus many new <a href="/project">features and bugfixes</a>.</p>
+                    and provide you with everything you love about KeePassX plus many new <a href="/#project">features and bugfixes</a>.</p>
             </div>
         </li>
 
@@ -574,7 +574,7 @@ menu:
         <li>
             <a id="faq-ssh-agent-git-bash" class="uk-accordion-title" href="#faq-ssh-agent-git-bash">How do I use KeePassXC SSH Agent integration with Git (Bash) on Windows?</a>
             <div class="uk-accordion-content">
-                <p>KeePassXC on Windows can be used with <a href="KeePassXC_UserGuide.html#_pageant_agent_on_windows" target="_blank">Pageant</a>
+                <p>KeePassXC on Windows can be used with <a href="KeePassXC_UserGuide.html#_openssh_agent_and_pageant_on_windows" target="_blank">Pageant</a>
                     or with Windows OpenSSH.<br> Git for Windows supports both options since version
                     <a href="https://github.com/git-for-windows/git/releases/tag/v2.33.0.windows.1" target="_blank">2.33.0</a>.</p>
                 <p>You will be prompted during installation of Git for Windows to pick the option you prefer – depending on


### PR DESCRIPTION
- fixes 404 error when navigating to Project section from FAQ
- fixes incorrect section anchor to OpenSSH agent and Pageant on Windows in the User Guide