### PR TITLE
Add `flatpak remote-add` command to instructions

### DIFF
--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -212,7 +212,10 @@
                                     <svg class="svg-icon" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 0c-.556 0-1.111.144-1.61.432l-7.603 4.39a3.217 3.217 0 0 0-1.61 2.788v8.78c0 1.151.612 2.212 1.61 2.788l7.603 4.39a3.217 3.217 0 0 0 3.22 0l7.603-4.39a3.217 3.217 0 0 0 1.61-2.788V7.61a3.217 3.217 0 0 0-1.61-2.788L13.61.432A3.218 3.218 0 0 0 12 0Zm0 2.358c.15 0 .299.039.431.115l7.604 4.39c.132.077.24.187.315.316L12 12v9.642a.863.863 0 0 1-.431-.116l-7.604-4.39a.866.866 0 0 1-.431-.746V7.61c0-.153.041-.302.116-.43L12 12Z"/></svg>
                                     <a class="uk-link-reset" href="https://flathub.org/apps/details/org.keepassxc.KeePassXC">Flatpak Package</a>
                                 </div>
-                                <div class="uk-margin-small-top"><code>flatpak install --user flathub org.keepassxc.KeePassXC</code></div>
+                                <div class="uk-margin-small-top">
+                                    <code>flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</code><br>
+                                    <code>flatpak install --user flathub org.keepassxc.KeePassXC</code>
+                                </div>
                             </div>
                             <div>
                                 <div class="uk-text-bold">

--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -214,6 +214,7 @@
                                 </div>
                                 <div class="uk-margin-small-top">
                                     <code>flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</code><br>
+                                    <br>
                                     <code>flatpak install --user flathub org.keepassxc.KeePassXC</code>
                                 </div>
                             </div>


### PR DESCRIPTION
There are no instructions on how to set up the flathub remote. Earlier, [the flatpak setup instructions](https://flatpak.org/setup/Debian) were enough, but in https://github.com/keepassxreboot/keepassxc-org/pull/99 the `--user` flag was added which requires the user to also set up their flathub remote using the `--user` flag. This was not obvious to me and it took me a few minutes for me to understand why I was getting the error `error: No remote refs found for ‘flathub’`.

I think explicitly telling the user how to add the flathub remote will help a lot of users.