### PR TITLE
Make terminal commands easily copyable

### DIFF
--- a/assets/js/copyable.js
+++ b/assets/js/copyable.js
@@ -1,0 +1,33 @@
+async function copyText(e) {
+    const btn = e.currentTarget;
+    const icon = btn.firstChild;
+    const textNode = btn.previousElementSibling;
+    try {
+        await navigator.clipboard.writeText(textNode.textContent);
+        icon.classList.remove('fa-copy');
+        icon.classList.add('fa-check');
+      } catch (err) {
+        alert(`Error copying text to clipboard: ${err.message}\n\nPlease copy manually instead.`);
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(textNode);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }
+    setTimeout(() => {
+        icon.classList.remove('fa-check');
+        icon.classList.add('fa-copy');
+      }, 1000);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    for (const el of document.querySelectorAll('.copyable')) {
+        const btn = document.createElement('button');
+        btn.title = 'Copy to clipboard';
+        const icon = document.createElement('i');
+        icon.classList.add('fa', 'fa-copy');
+        btn.appendChild(icon);
+        btn.addEventListener('click', copyText);
+        el.appendChild(btn);
+    }
+});

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -45,6 +45,7 @@ $global-warning-background: #faa05a;
 $global-danger-background: #f0506e;
 
 $global-border: #dadada;
+$global-border-radius: 5px;
 
 // Buttons
 $button-default-background: #fff;

--- a/assets/scss/copyable.scss
+++ b/assets/scss/copyable.scss
@@ -1,0 +1,47 @@
+.copyable {
+    display: flex;
+    margin-top: 5px;
+
+    code > span {
+        display: inline !important;
+    }
+
+    .highlight {
+        overflow-x: auto;
+        margin: 0;
+        width: 100%;
+
+        pre {
+            border-radius: $global-border-radius;
+            margin: 0;
+            white-space: pre-wrap;
+        }
+        &:not(:only-child) pre {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+
+        code[data-lang="shell"]::before {
+            display: inline;
+            content: "$ ";
+        }
+
+        code[data-lang="powershell"]::before {
+            display: inline;
+            content: "> ";
+        }
+    }
+
+    button {
+        cursor: pointer;
+        margin: 0;
+        border: 1px solid $global-border;
+        border-left: 0px;
+        border-top-right-radius: $global-border-radius;
+        border-bottom-right-radius: $global-border-radius;
+        background-color: lighten($button-default-color, 75%);
+    }
+    button:hover {
+        background-color: lighten($button-default-color, 70%);
+    }
+}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -27,3 +27,6 @@
 @import "theme/global";
 @import "theme/footer";
 @import "theme/index";
+
+// Copyable
+@import "copyable";

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,6 +19,8 @@
         | resources.ToCSS (dict "outputStyle" "compressed" "enableSourceMap" (not hugo.IsProduction) "includePaths" (slice "."))
         | fingerprint -}}
     <link href="{{ $style.RelPermalink }}" rel="stylesheet">
+    {{ $script := resources.Get "js/copyable.js" | fingerprint -}}
+    <script type="module" src="{{ $script.RelPermalink }}"></script>
 
     {{- $uikitMain := resources.Get "node_modules/uikit/dist/js/uikit.min.js" }}
     {{- $uikitIcons := resources.Get "node_modules/uikit/dist/js/uikit-icons.min.js" }}

--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -1,4 +1,5 @@
 {{- define "main" }}
+{{- $highlightOptions := dict "lineNos" false "style" "autumn" -}}
 <div class="uk-section uk-section-small uk-margin-medium-bottom">
     <div class="uk-container uk-margin-medium">
         <h1 hidden>Download</h1>
@@ -34,8 +35,8 @@
                 </div>
 
                 <div class="uk-card uk-card-default uk-width-xlarge uk-margin-auto uk-margin-large uk-text-small uk-text-left" id="macos-packages-more">
-                    <div class="uk-card-header uk-text-decoration-none uk-background-muted" uk-toggle="target: #macos-packages-more .uk-card-body, #macos-packages-more .toggle; animation: uk-animation-fade">
-                        <h3 class="uk-text-small uk-position-relative">
+                    <div class="uk-card-header uk-text-decoration-none uk-background-secondary" uk-toggle="target: #macos-packages-more .uk-card-body, #macos-packages-more .toggle; animation: uk-animation-fade">
+                        <h3 class="uk-text-small uk-text-bold uk-position-relative">
                             See more options
                             <i class="fa-solid fa-chevron-up uk-position-center-right toggle" hidden></i>
                             <i class="fa-solid fa-chevron-down uk-position-center-right toggle"></i>
@@ -69,7 +70,9 @@
                                     <a class="uk-link-reset" href="https://formulae.brew.sh/cask/keepassxc">Homebrew Cask</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>brew install --cask keepassxc</code>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "brew install --cask keepassxc" "shell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -99,8 +102,8 @@
                 </div>
 
                 <div class="uk-card uk-card-default uk-width-xlarge uk-margin-auto uk-margin-large uk-text-small uk-text-left" id="windows-packages-more">
-                    <div class="uk-card-header uk-text-decoration-none uk-background-muted" uk-toggle="target: #windows-packages-more .uk-card-body, #windows-packages-more .toggle; animation: uk-animation-fade">
-                        <h3 class="uk-text-small uk-position-relative">
+                    <div class="uk-card-header uk-text-decoration-none uk-background-secondary" uk-toggle="target: #windows-packages-more .uk-card-body, #windows-packages-more .toggle; animation: uk-animation-fade">
+                        <h3 class="uk-text-small uk-text-bold uk-position-relative">
                             See more options
                             <i class="fa-solid fa-chevron-up uk-position-center-right toggle" hidden></i>
                             <i class="fa-solid fa-chevron-down uk-position-center-right toggle"></i>
@@ -160,7 +163,9 @@
                                     <i class="fa-brands fa-windows"></i> <a class="uk-link-reset" href="https://winget.run/pkg/KeePassXCTeam/KeePassXC">Windows Package Manager</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>winget install -e --id KeePassXCTeam.KeePassXC</code>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "winget install -e --id KeePassXCTeam.KeePassXC" "powershell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                             <div>
@@ -169,7 +174,9 @@
                                     <a class="uk-link-reset" href="https://community.chocolatey.org/packages/keepassxc">Chocolatey</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>choco install keepassxc</code>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "choco install keepassxc" "powershell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -200,7 +207,7 @@
 
                 <div class="uk-card uk-card-default uk-width-xlarge uk-margin-auto uk-margin-large uk-text-small uk-text-left" id="linux-packages-official">
                     <div class="uk-card-header uk-text-decoration-none uk-background-secondary" uk-toggle="target: #linux-packages-official .uk-card-body, #linux-packages-official .toggle; animation: uk-animation-fade">
-                        <h3 class="uk-text-small uk-position-relative">
+                        <h3 class="uk-text-small uk-text-bold uk-position-relative">
                             Other Official Linux Packages
                             <i class="fa-solid fa-chevron-down uk-position-center-right toggle" hidden></i>
                             <i class="fa-solid fa-chevron-up uk-position-center-right toggle"></i>
@@ -214,9 +221,12 @@
                                     <a class="uk-link-reset" href="https://flathub.org/apps/details/org.keepassxc.KeePassXC">Flatpak Package</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</code><br>
-                                    <br>
-                                    <code>flatpak install --user flathub org.keepassxc.KeePassXC</code>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo" "shell" $highlightOptions }}
+                                    </div>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "flatpak install --user flathub org.keepassxc.KeePassXC" "shell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                             <div>
@@ -224,7 +234,11 @@
                                     <svg class="svg-icon" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M13.804 13.367V5.69l5.292 2.362-5.292 5.315zM3.701 23.514l6.49-12.22 2.847 2.843L3.7 23.514zM0 .486l13.355 4.848v8.484L0 .486zM21.803 5.334H14.11L24 9.748z"/></svg>
                                     <a class="uk-link-reset" href="https://snapcraft.io/keepassxc">Snap Package</a>
                                 </div>
-                                <div class="uk-margin-small-top"><code>sudo snap install keepassxc</code></div>
+                                <div class="uk-margin-small-top">
+                                    <div class="copyable">
+                                        {{ transform.Highlight "sudo snap install keepassxc" "shell" $highlightOptions }}
+                                    </div>
+                                </div>
                                 <div class="uk-margin-small-top">
                                     <a href="https://raw.githubusercontent.com/keepassxreboot/keepassxc/latest/utils/keepassxc-snap-helper.sh">KeePassXC-Browser Helper Script</a>
                                     <span class="uk-text-muted">(Right click &rarr; Save link as&hellip;)</span>
@@ -235,9 +249,15 @@
                                     <i class="fa-brands fa-ubuntu"></i> <a class="uk-link-reset" href="https://launchpad.net/~phoerious/+archive/ubuntu/keepassxc">Ubuntu PPA</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>sudo add-apt-repository ppa:phoerious/keepassxc</code><br>
-                                    <code>sudo apt update</code><br>
-                                    <code>sudo apt install keepassxc</code>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "sudo add-apt-repository ppa:phoerious/keepassxc" "shell" $highlightOptions }}
+                                    </div>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "sudo apt update" "shell" $highlightOptions }}
+                                    </div>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "sudo apt install keepassxc" "shell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -246,8 +266,8 @@
 
 
                 <div class="uk-card uk-card-default uk-width-xlarge uk-margin-auto uk-margin-large uk-text-small uk-text-left" id="linux-packages-more">
-                    <div class="uk-card-header uk-text-decoration-none uk-background-muted" uk-toggle="target: #linux-packages-more .uk-card-body, #linux-packages-more .toggle; animation: uk-animation-fade">
-                        <h3 class="uk-text-small uk-position-relative">
+                    <div class="uk-card-header uk-text-decoration-none uk-background-secondary" uk-toggle="target: #linux-packages-more .uk-card-body, #linux-packages-more .toggle; animation: uk-animation-fade">
+                        <h3 class="uk-text-small uk-text-bold uk-position-relative">
                             See more options
                             <i class="fa-solid fa-chevron-up uk-position-center-right toggle" hidden></i>
                             <i class="fa-solid fa-chevron-down uk-position-center-right toggle"></i>
@@ -260,7 +280,9 @@
                                     <i class="fa-brands fa-ubuntu"></i> <a class="uk-link-reset" href="https://packages.ubuntu.com/source/keepassxc">Ubuntu / Debian (distribution package)</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>sudo apt install keepassxc</code>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "sudo apt install keepassxc" "shell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                             <div>
@@ -269,7 +291,9 @@
                                     <a class="uk-link-reset" href="https://src.fedoraproject.org/rpms/keepassxc">Fedora</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>sudo dnf install keepassxc</code>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "sudo dnf install keepassxc" "shell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                             <div>
@@ -278,7 +302,9 @@
                                     <a class="uk-link-reset" href="https://archlinux.org/packages/extra/x86_64/keepassxc/">Arch Linux</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>sudo pacman -S keepassxc</code>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "sudo pacman -S keepassxc" "shell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                             <div>
@@ -287,7 +313,9 @@
                                     <a class="uk-link-reset" href="https://software.opensuse.org/package/keepassxc">OpenSUSE</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>sudo zypper install keepassxc</code>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "sudo zypper install keepassxc" "shell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                             <div>
@@ -296,7 +324,9 @@
                                     <a class="uk-link-reset" href="https://packages.gentoo.org/packages/app-admin/keepassxc">Gentoo</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>sudo emerge app-admin/keepassxc</code>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "sudo emerge app-admin/keepassxc" "shell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                             <div>
@@ -305,7 +335,10 @@
                                     <a class="uk-link-reset" href="https://packages.gentoo.org/packages/app-admin/keepassxc">RHEL 8 / CentOS Stream</a>
                                 </div>
                                 <div class="uk-margin-small-top">
-                                    <code>sudo dnf install keepassxc</code> (<a href="https://fedoraproject.org/wiki/EPEL">Enable EPEL repository</a>)
+                                    <a href="https://docs.fedoraproject.org/en-US/epel/">Enable EPEL repository</a>
+                                    <div class="copyable">
+                                        {{ transform.Highlight "sudo dnf install keepassxc" "shell" $highlightOptions }}
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
This makes the terminal commands on the Downloads page easily copyable with a button click.

Screenshot:

![image](https://github.com/keepassxreboot/keepassxc-org/assets/2809491/9a6ac870-98b7-4879-b4d2-f850b0e89544)

Windows commands have the `>` prompt. The prompt symbols are defined in CSS so they are not selectable. 🤩

**Note that the Downloads page currently doesn't work when JavaScript is disabled! I have changes locally that fix this, but I want to submit them separately to make review easier.**

If the user has blocked clipboard access then they will get an error alert and the text is selected to make it easier for them to copy it manually. I was able to test this in Firefox by setting `dom.allow_cut_copy=false` in `about:config`. If anyone can figure out a way to disable clipboard write in Chrome please write a comment below (the Clipboard site permission doesn't do it).

<img width="406" alt="Screenshot 2023-09-16 at 12 01 26" src="https://github.com/keepassxreboot/keepassxc-org/assets/1991151/50557257-cfde-424d-8789-29f09a286f8f">

The look and behavior of this is inspired by the Homebrew copy widget on this page: https://formulae.brew.sh/cask/keepassxc

Please let me know if you want any changes.
