### PR TITLE
Adds a tab for the browser extensions on the downloads page

### DIFF
--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -354,13 +354,13 @@
                         </div>
                         <div>
                             <div class="uk-margin-small" style="height: 70px">
-                                <img src="{{ .Site.BaseURL }}assets/img/browser-icons/chrome.svg" width="60" alt="Firefox logo">
+                                <img src="{{ .Site.BaseURL }}assets/img/browser-icons/chrome.svg" width="60" alt="Chrome logo">
                             </div>
                             <a href="https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk" target="_blank" class="uk-button uk-button-default uk-margin-small uk-display-block">Install</a>
                         </div>
                         <div>
                             <div class="uk-margin-small" style="height: 70px">
-                                <img src="{{ .Site.BaseURL }}assets/img/browser-icons/edge.svg" width="60" alt="Firefox logo">
+                                <img src="{{ .Site.BaseURL }}assets/img/browser-icons/edge.svg" width="60" alt="Edge logo">
                             </div>
                             <a href="https://microsoftedge.microsoft.com/addons/detail/keepassxcbrowser/pdffhmdngciaglkoonimfcmckehcpafo" target="_blank" class="uk-button uk-button-default uk-margin-small uk-display-block">Install</a>
                         </div>

--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -345,24 +345,24 @@
                     <h2 class="uk-card-title uk-margin-small">Get the browser extension</h2>
                     <p>Once you have KeePassXC set up on your computer, get the KeePassXC browser extension to automatically fill in your online passwords in the browser.</p>
 
-                    <div class="uk-margin-medium uk-grid uk-child-width-1-3" uk-grid>
+                    <div class="uk-flex uk-flex-middle uk-flex-center uk-width-1-1" style="gap: 1rem;">
                         <div>
-                            <div class="uk-margin-small" style="height: 70px">
+                            <div style="height: 70px">
                                 <img src="{{ .Site.BaseURL }}assets/img/browser-icons/firefox.svg" width="60" alt="Firefox logo">
                             </div>
-                            <a href="https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/" target="_blank" class="uk-button uk-button-default uk-margin-small uk-display-block">Install</a>
+                            <a href="https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/" target="_blank" class="uk-button uk-button-default uk-display-block">Install</a>
                         </div>
                         <div>
-                            <div class="uk-margin-small" style="height: 70px">
+                            <div style="height: 70px">
                                 <img src="{{ .Site.BaseURL }}assets/img/browser-icons/chrome.svg" width="60" alt="Chrome logo">
                             </div>
-                            <a href="https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk" target="_blank" class="uk-button uk-button-default uk-margin-small uk-display-block">Install</a>
+                            <a href="https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk" target="_blank" class="uk-button uk-button-default uk-display-block">Install</a>
                         </div>
                         <div>
-                            <div class="uk-margin-small" style="height: 70px">
+                            <div style="height: 70px">
                                 <img src="{{ .Site.BaseURL }}assets/img/browser-icons/edge.svg" width="60" alt="Edge logo">
                             </div>
-                            <a href="https://microsoftedge.microsoft.com/addons/detail/keepassxcbrowser/pdffhmdngciaglkoonimfcmckehcpafo" target="_blank" class="uk-button uk-button-default uk-margin-small uk-display-block">Install</a>
+                            <a href="https://microsoftedge.microsoft.com/addons/detail/keepassxcbrowser/pdffhmdngciaglkoonimfcmckehcpafo" target="_blank" class="uk-button uk-button-default uk-display-block">Install</a>
                         </div>
                     </div>
                 </div>

--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -8,6 +8,7 @@
             <li><a href="#tab-windows"><i class="fa-brands fa-windows"></i> Windows</a></li>
             <li><a href="#tab-linux"><i class="fa-brands fa-linux"></i> Linux</a></li>
             <li><a href="#tab-code"><i class="fa-solid fa-code"></i> Source Code</a></li>
+            <li><a href="#tab-browser"><i class="fa-solid fa-globe"></i> Browser Extention</a></li>
         </ul>
 
         {{ $gh := "https://github.com/keepassxreboot/keepassxc/releases/download/" }}
@@ -330,6 +331,40 @@
                     <a href="{{ $gh }}{{ .Params.version.version }}/keepassxc-{{ .Params.version.version }}{{ .Params.version.suffix.source.tarball }}-src.tar.xz.sig" class="uk-padding-small"><i class="fa-solid fa-key"></i> PGP Signature</a> &ndash;
                     <a href="{{ $gh }}{{ .Params.version.version }}/keepassxc-{{ .Params.version.version }}{{ .Params.version.suffix.source.tarball }}-src.tar.xz.DIGEST" class="uk-padding-small"><i class="fa-solid fa-hashtag"></i> SHA-256 Digest</a> &ndash;
                     <a href="{{ .Site.BaseURL }}verifying-signatures" class="uk-padding-small"><i class="fa-solid fa-circle-question"></i> Verifying Signatures</a>
+                </div>
+            </div>
+
+            <div id="tab-browser">
+                <div class="download-main">
+                    <div class="uk-margin-large-top uk-margin-medium-bottom">
+                        <h2>KeePassXC Browser Extension</h2>
+                        <p>Autofill passwords from your local KeepassXC install.</p>
+                    </div>
+
+                    <div class="uk-flex uk-flex-middle uk-flex-center uk-width-1-1" style="gap: 1rem;">
+                        <div>
+                            <div class="uk-margin-small" style="height: 70px">
+                                <img src="{{ .Site.BaseURL }}assets/img/browser-icons/firefox.svg" width="60" alt="Firefox logo">
+                            </div>
+                            <a href="https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/" target="_blank" class="uk-button uk-button-default uk-display-block">Install</a>
+                        </div>
+                        <div>
+                            <div class="uk-margin-small" style="height: 70px">
+                                <img src="{{ .Site.BaseURL }}assets/img/browser-icons/chrome.svg" width="60" alt="Chrome logo">
+                            </div>
+                            <a href="https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk" target="_blank" class="uk-button uk-button-default uk-display-block">Install</a>
+                        </div>
+                        <div>
+                            <div class="uk-margin-small" style="height: 70px">
+                                <img src="{{ .Site.BaseURL }}assets/img/browser-icons/edge.svg" width="60" alt="Edge logo">
+                            </div>
+                            <a href="https://microsoftedge.microsoft.com/addons/detail/keepassxcbrowser/pdffhmdngciaglkoonimfcmckehcpafo" target="_blank" class="uk-button uk-button-default uk-display-block">Install</a>
+                        </div>
+                    </div>
+
+                    <div class="uk-text-small uk-margin-medium uk-margin-medium-bottom uk-text-muted">
+                        <a href="https://github.com/keepassxreboot/keepassxc-browser" class="uk-padding-small"><i class="fa-solid fa-code"></i> Source Code</a>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Closes #123 

### Changes
- Fixes alt text for the browser logos in the existing "Next step" sequence
- Fixes the offset button text at smaller breakpoints by switching to flexbox and using `gap` instead of `margin`.
- Adds a tab with links to download the browser extensions and their source code alongside the other downloads on the site

### Screenshot

<img width="1792" alt="Screenshot 2023-10-26 at 11 34 28 AM" src="https://github.com/keepassxreboot/keepassxc-org/assets/5672810/fa437ff7-7bc7-4079-a3a6-5c17310badd9">
