### PR TITLE
Remove mentions of KeePassHTTP from FAQ

### DIFF
--- a/content/docs/index.html
+++ b/content/docs/index.html
@@ -168,10 +168,9 @@ menu:
         <li>
             <a id="faq-security-network" class="uk-accordion-title" href="#faq-security-network">I see that KeePassXC requires network access. What for?</a>
             <div class="uk-accordion-content">
-                <p>KeePassXC needs network access for downloading website icons (favicons) for password entries and for
-                    providing KeePassHTTP-compatible browser extensions with access to your database. Both features are optional
+                <p>KeePassXC needs network access for downloading website icons (favicons) for password entries. This feature is optional
                     and opt-in. KeePassXC will never access any network resource without your explicit prior consent. If you
-                    don't use either of these features, you may also compile KeePassXC without any networking code (see
+                    don't use this feature, you may also compile KeePassXC without any networking code (see
                     next question).</p>
             </div>
         </li>
@@ -384,8 +383,8 @@ menu:
         <li>
             <a id="faq-browser" class="uk-accordion-title" href="#faq-browser">Does KeePassXC support browser extensions?</a>
             <div class="uk-accordion-content">
-                <p>Yes. KeePassXC supports KeePassHTTP-Connector as a legacy browser integration and a newer extension KeePassXC-Browser.
-                    You can download KeePassXC-Browser for <a href="https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/">Mozilla Firefox</a> and
+                <p>Yes. KeePassXC supports the extension KeePassXC-Browser.
+                    You can download it for <a href="https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/">Mozilla Firefox</a> and
                     <a href="https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk">Google Chrome / Chromium / Vivaldi</a>.
                     Firefox ESR (52.x) is supported, but the following features are disabled because of WebExtension API limitations:</p>
                 <ul>


### PR DESCRIPTION
KeePassHTTP support has been removed a few years ago. Most places in the docs seem to have been updated, but the FAQ still talked about it as a supported browser integration. I think the wording could be improved, edits/suggestions are welcome :)