### PR TITLE
Replace resources.ToCSS with css.Sass due to deprecation

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,7 +16,7 @@
     {{- block "head-meta" . }}{{ end }}
     {{ $style := resources.Get "scss/style.scss"
         | resources.ExecuteAsTemplate "assets/css/style.css" .
-        | resources.ToCSS (dict "outputStyle" "compressed" "enableSourceMap" (not hugo.IsProduction) "includePaths" (slice "."))
+        | css.Sass (dict "outputStyle" "compressed" "enableSourceMap" (not hugo.IsProduction) "includePaths" (slice "."))
         | fingerprint -}}
     <link href="{{ $style.RelPermalink }}" rel="stylesheet">
     {{ $script := resources.Get "js/copyable.js" | fingerprint -}}
@@ -24,7 +24,7 @@
     <noscript>
     {{ $style := resources.Get "scss/noscript.scss"
           | resources.ExecuteAsTemplate "assets/css/noscript.css" .
-          | resources.ToCSS (dict "outputStyle" "compressed" "enableSourceMap" (not hugo.IsProduction) "includePaths" (slice "."))
+          | css.Sass (dict "outputStyle" "compressed" "enableSourceMap" (not hugo.IsProduction) "includePaths" (slice "."))
           | fingerprint -}}
     <link href="{{ $style.RelPermalink }}" rel="stylesheet">
     </noscript>


### PR DESCRIPTION
**Setup**

```
jtorres@MacBookAir keepassxc-org % hugo version
hugo v0.147.0+extended+withdeploy darwin/arm64 BuildDate=2025-04-25T15:26:28Z VendorInfo=brew
jtorres@MacBookAir keepassxc-org % 
jtorres@MacBookAir keepassxc-org % npm list
keepassxc.org@1.0.0 /Users/jtorres/GitProjects/keepassxc-org
├── @fortawesome/fontawesome-free@6.7.1
├── jquery@3.7.1
├── ua-parser-js@2.0.0
└── uikit@3.21.16
```

**Details**

On recent versions of Hugo (such as v0.147.0), the site fails to build due to the following deprecation error:

ERROR deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and subsequently removed. Use css.Sass instead.

Full log:

```
jtorres@MacBookAir keepassxc-org % hugo      
Start building sites … 
hugo v0.147.0+extended+withdeploy darwin/arm64 BuildDate=2025-04-25T15:26:28Z VendorInfo=brew

ERROR deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and subsequently removed. Use css.Sass instead.
WARNING on line 40, column 17 of /Users/jtorres/GitProjects/keepassxc-org/assets/scss/theme/_global.scss:
Compound selectors may no longer be extended.
Consider `@extend .uk-card-default, .uk-card-hover, :hover` instead.
See http://bit.ly/ExtendCompound for details.

Total in 287 ms
Error: error building site: logged 1 error(s)
jtorres@MacBookAir keepassxc-org % 
```

The site builds fine after replacing resources.ToCSS with css.Sass in layouts/_default/baseof.html:

```
jtorres@MacBookAir keepassxc-org % hugo
Start building sites … 
hugo v0.147.0+extended+withdeploy darwin/arm64 BuildDate=2025-04-25T15:26:28Z VendorInfo=brew

WARNING on line 40, column 17 of /Users/jtorres/GitProjects/keepassxc-org/assets/scss/theme/_global.scss:
Compound selectors may no longer be extended.
Consider `@extend .uk-card-default, .uk-card-hover, :hover` instead.
See http://bit.ly/ExtendCompound for details.


                   | EN   
-------------------+------
  Pages            |  67  
  Paginator pages  |   4  
  Non-page files   |   0  
  Static files     | 100  
  Processed images |   0  
  Aliases          |   3  
  Cleaned          |   0  

Total in 285 ms
```

Like resources.ToCSS, css.Sass also returns resource.Resource.

Also tested the change with an older version of Hugo (v0.135.0) and the site builds successfully as well. 

**References**

https://gohugo.io/functions/resources/tocss/
