### PR TITLE
make the "who should use this" faq have it's own anchor id

### DIFF
--- a/content/docs/index.html
+++ b/content/docs/index.html
@@ -58,7 +58,7 @@ menu:
             </div>
         </li>
         <li>
-            <a id="faq-security-why-pm" class="uk-accordion-title" href="#faq-security-why-pm">Who should use this?</a>
+            <a id="faq-security-who-should-use" class="uk-accordion-title" href="#faq-security-who-should-use">Who should use this?</a>
             <div class="uk-accordion-content">
                 <p>Password managers (in general) exist to help users limit the scope of hacked accounts by making it simple 
                     to use a unique password per website or application. KeePassXC is specifically for individuals who want 


### PR DESCRIPTION
Looking at the docs after the merge of #143, realized that "Why would I use a password Manager" and "Who should use this" shared the same anchor ID's (making linking to one or the other not work as expected)