### PR TITLE
Add NodeJS/NPM installation in the Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,22 @@ Website sources for https://keepassxc.org.
 
 This website uses [Hugo](https://gohugo.io/). To build the sources, you need to install it first.
 
+Additionally, NPM (bundled with NodeJS) is required to install other dependencies.
+
 Linux:
 ```bash
 sudo snap install hugo
+sudo snap install node --classic
 ```
 
 macOS:
 ```bash
-brew install hugo
+brew install hugo node
 ```
 
 Windows:
 ```bash
-winget install Hugo.Hugo.Extended
+winget install Hugo.Hugo.Extended OpenJS.NodeJS
 ```
 
 ## Build website


### PR DESCRIPTION
In the "Build website" section (README doc), installing NPM dependencies is required before building the site with Hugo. This implies that NPM is also a prerequisite. 

Hence, it would be helpful to document the installation of NPM in the "Prerequisites" section as well with the already listed package managers (snap, homebrew, winget).

References:
https://nodejs.org/en/download/package-manager/all
https://snapcraft.io/node
