### PR TITLE
Fix browser integration link id

### DIFF
--- a/content/docs/index.html
+++ b/content/docs/index.html
@@ -14,7 +14,7 @@ menu:
                 up and running quickly.</li>
             <li>Looking for more comprehensive documentation? Our <strong><a href="KeePassXC_UserGuide.html" target="_blank"><i class="fa-solid fa-book"></i> User Guide</a></strong> is there to help.</li>
             <li>Need help troubleshooting the browser integration? Check the
-                <strong><a href="KeePassXC_GettingStarted.html#_setup_browser_integration" target="_blank"><i class="fa-solid fa-globe"></i> Setup Browser Integration</a></strong> section.</li>
+                <strong><a href="KeePassXC_GettingStarted.html#_browser_integration" target="_blank"><i class="fa-solid fa-globe"></i> Setup Browser Integration</a></strong> section.</li>
             <li><strong><a href="https://github.com/keepassxreboot/keepassxc/wiki" target="_blank"><i class="fa-solid fa-gears"></i> Build instructions</a></strong> and other
                 technical guides can be found in the GitHub Wiki.</li>
             <li>Looking for an audit of KeePassXC? Read the <a href="#faq-audit">FAQ entry</a> or 


### PR DESCRIPTION
This fixes the "Setup Browser Integration" link (Docs/FAQ), which currently points to id "#_setup_browser_integration". The "KeePassXC_GettingStarted" document has an id of "#_browser_integration" for this section.