### PR TITLE
Add direct links to matrix on team page

### DIFF
--- a/content/team.html
+++ b/content/team.html
@@ -23,8 +23,8 @@ menu:
 
 <p>You can contact us via <strong>[matrix]</strong>, a free chat protocol. We have two channels, one for user questions and one for development-related discussions:</p>
 <ul>
-    <li><code>#keepassxc:mozilla.org</code> <a href="https://app.element.io/#/room/#keepassxc:mozilla.org" target="_blank">Element.io web chat</a> (user's channel)</li>
-    <li><code>#keepassxc-dev:mozilla.org</code> <a href="https://app.element.io/#/room/#keepassxc-dev:mozilla.org" target="_blank">Element.io web chat</a> (developer's channel)</li>
+    <li><code><a href="https://matrix.to/#/#keepassxc:mozilla.org">#keepassxc:mozilla.org</a></code> <a href="https://app.element.io/#/room/#keepassxc:mozilla.org" target="_blank">Element.io web chat</a> (user's channel)</li>
+    <li><code><a href="https://matrix.to/#/keepassxc-dev:mozilla.org">#keepassxc-dev:mozilla.org</a></code> <a href="https://app.element.io/#/room/#keepassxc-dev:mozilla.org" target="_blank">Element.io web chat</a> (developer's channel)</li>
 </ul>
 <p>Please be patient when asking a question! You may not get an immediate answer, but someone will respond to you eventually.</p>
 


### PR DESCRIPTION
Useful for people that use other clients or instances of Element.